### PR TITLE
chore: スタート時の時間入力にzodを導入

### DIFF
--- a/src/__test__/integration/background-ui-communication.test.js
+++ b/src/__test__/integration/background-ui-communication.test.js
@@ -206,17 +206,17 @@ describe("Background-UI Communication Integration", () => {
       const result1 = await handleEvents("timer/start", { minutes: 0 });
       expect(result1.success).toBe(false);
       expect(result1.severity).toBe(Constants.SEVERITY_LEVELS.FATAL);
-      expect(result1.error).toContain("Invalid minutes");
+      expect(result1.error).toContain("Too small");
 
       const result2 = await handleEvents("timer/start", { minutes: -5 });
       expect(result2.success).toBe(false);
       expect(result2.severity).toBe(Constants.SEVERITY_LEVELS.FATAL);
-      expect(result2.error).toContain("Invalid minutes");
+      expect(result2.error).toContain("Too small");
 
       const result3 = await handleEvents("timer/start", {});
       expect(result3.success).toBe(false);
       expect(result3.severity).toBe(Constants.SEVERITY_LEVELS.FATAL);
-      expect(result3.error).toContain("Invalid minutes");
+      expect(result3.error).toContain("expected number, received undefined");
     });
 
     it("should execute timer/pause event correctly", async () => {

--- a/src/__test__/unit/events.test.js
+++ b/src/__test__/unit/events.test.js
@@ -193,7 +193,7 @@ describe("Events", () => {
 
       expect(result.success).toBe(false);
       expect(result.severity).toBe(Constants.SEVERITY_LEVELS.FATAL);
-      expect(result.error).toContain("Invalid minutes: must be at least 5");
+      expect(result.error).toContain("Too small");
     });
 
     test('should return fatal error when "timer/start" is called with minutes above maximum', async () => {
@@ -201,7 +201,7 @@ describe("Events", () => {
 
       expect(result.success).toBe(false);
       expect(result.severity).toBe(Constants.SEVERITY_LEVELS.FATAL);
-      expect(result.error).toContain("Invalid minutes: must be at most 300");
+      expect(result.error).toContain("Too big");
     });
 
     test('should return fatal error when "timer/start" is called without minutes', async () => {
@@ -209,7 +209,7 @@ describe("Events", () => {
 
       expect(result.success).toBe(false);
       expect(result.severity).toBe(Constants.SEVERITY_LEVELS.FATAL);
-      expect(result.error).toContain("Invalid minutes: parameter is required");
+      expect(result.error).toContain("expected number, received undefined");
     });
 
     test('should return fatal error when "timer/start" is called with non-number minutes', async () => {
@@ -217,7 +217,7 @@ describe("Events", () => {
 
       expect(result.success).toBe(false);
       expect(result.severity).toBe(Constants.SEVERITY_LEVELS.FATAL);
-      expect(result.error).toContain("Invalid minutes: must be a number");
+      expect(result.error).toContain("expected number, received string");
     });
 
     test('should return fatal error when "timer/start" is called with NaN', async () => {
@@ -225,7 +225,7 @@ describe("Events", () => {
 
       expect(result.success).toBe(false);
       expect(result.severity).toBe(Constants.SEVERITY_LEVELS.FATAL);
-      expect(result.error).toContain("Invalid minutes: must be a number");
+      expect(result.error).toContain("expected number, received NaN");
     });
 
     test('should enable block and start tick when "timer/start" is invoked', async () => {


### PR DESCRIPTION
タイマースタート時のイベント("timer/start")において、タイマー計測時間指定（5~300）のバリデーションをif文で実装していたため、zodに差し替え。伴ってテストを修正。